### PR TITLE
fix: added compatibility for pimcore 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 Thumbs.db
 *.log
+vendor
 
 # composer
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
+    "pimcore/ecommerce-framework-bundle": "^1.1",
     "pimcore/pimcore": "^11.0"
   },
   "require-dev": {

--- a/src/Datatrans/Installer.php
+++ b/src/Datatrans/Installer.php
@@ -19,9 +19,9 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Tools\PaymentProviderInstaller;
 
 class Installer extends PaymentProviderInstaller
 {
-    protected $bricksPath = __DIR__ . '/../../install/objectbrick_sources/';
+    protected string $bricksPath = __DIR__ . '/../../install/objectbrick_sources/';
 
-    protected $bricksToInstall = [
+    protected array $bricksToInstall = [
         'PaymentProviderDatatrans' => 'objectbrick_PaymentProviderDatatrans_export.json'
     ];
 }

--- a/src/PaymentManager/Payment/Datatrans.php
+++ b/src/PaymentManager/Payment/Datatrans.php
@@ -88,7 +88,7 @@ class Datatrans extends AbstractPayment implements RecurringPaymentInterface
         );
     }
 
-    protected function processOptions(array $options)
+    protected function processOptions(array $options) : void
     {
         parent::processOptions($options);
 

--- a/src/PaymentManager/Payment/Datatrans.php
+++ b/src/PaymentManager/Payment/Datatrans.php
@@ -607,7 +607,7 @@ class Datatrans extends AbstractPayment implements RecurringPaymentInterface
     /**
      * @param array $authorizedData
      */
-    public function setAuthorizedData(array $authorizedData)
+    public function setAuthorizedData(array $authorizedData): void
     {
         $this->authorizedData = $authorizedData;
     }
@@ -798,17 +798,12 @@ XML;
     /**
      * @param object $paymentBrick
      */
-    public function setRecurringPaymentSourceOrderData(AbstractOrder $sourceOrder, $paymentBrick): bool
+    public function setRecurringPaymentSourceOrderData(AbstractOrder $sourceOrder, object $paymentBrick): void
     {
         if (method_exists($paymentBrick, 'setSourceOrder')) {
             $paymentBrick->setSourceOrder($sourceOrder);
-
-            return true;
         }
-
         Logger::err('Could not set source order for performed alias payment.');
-
-        return false;
     }
 
     /**
@@ -816,7 +811,7 @@ XML;
      *
      * @throws \Exception
      */
-    public function applyRecurringPaymentCondition(Concrete $orderListing, $additionalParameters = []): Concrete
+    public function applyRecurringPaymentCondition(Concrete $orderListing, array $additionalParameters = []): void
     {
         $providerBrickName = "PaymentProvider{$this->getName()}";
         $orderListing->addObjectbrick($providerBrickName);
@@ -830,7 +825,5 @@ XML;
 
         $orderListing->setOrderKey("`{$providerBrickName}`.`paymentFinished`", false);
         $orderListing->setOrder('DESC');
-
-        return $orderListing;
     }
 }


### PR DESCRIPTION
added minimum compatiblity and small adaptions for this bundle to have it runnable within Pimcore 11:

- added "vendor" folder to gitignore
- added ecommerce framework bundle as the Installer Class of this Bundle has a direct dependency to it
- added types for `$bricksPath` and `bricksToInstall` to be compatible with the base class